### PR TITLE
Add optional resume_download argument to help download large models

### DIFF
--- a/rudalle/dalle/__init__.py
+++ b/rudalle/dalle/__init__.py
@@ -188,7 +188,7 @@ def get_rudalle_model(name, pretrained=True, fp16=False, device='cpu', use_auth_
         cache_dir = os.path.join(cache_dir, name)
         config_file_url = hf_hub_url(repo_id=config['repo_id'], filename=config['filename'])
         cached_download(config_file_url, cache_dir=cache_dir, force_filename=config['filename'],
-                        use_auth_token=use_auth_token)
+                        use_auth_token=use_auth_token, resume_download=True)
         checkpoint = torch.load(os.path.join(cache_dir, config['filename']), map_location=device)
 
         pbar = tqdm(total=len(checkpoint.keys()))

--- a/rudalle/dalle/__init__.py
+++ b/rudalle/dalle/__init__.py
@@ -151,7 +151,7 @@ MODELS = {
 
 
 def get_rudalle_model(name, pretrained=True, fp16=False, device='cpu', use_auth_token=None,
-                      cache_dir='/tmp/rudalle', **model_kwargs):
+                      cache_dir='/tmp/rudalle', resume_download=False, **model_kwargs):
     assert name in MODELS
 
     if fp16 and device == 'cpu':
@@ -188,7 +188,7 @@ def get_rudalle_model(name, pretrained=True, fp16=False, device='cpu', use_auth_
         cache_dir = os.path.join(cache_dir, name)
         config_file_url = hf_hub_url(repo_id=config['repo_id'], filename=config['filename'])
         cached_download(config_file_url, cache_dir=cache_dir, force_filename=config['filename'],
-                        use_auth_token=use_auth_token, resume_download=True)
+                        use_auth_token=use_auth_token, resume_download=resume_download)
         checkpoint = torch.load(os.path.join(cache_dir, config['filename']), map_location=device)
 
         pbar = tqdm(total=len(checkpoint.keys()))


### PR DESCRIPTION
It's kinda pain to download large models with unstable network connection. 
For instance, i've started seeing this type of error [(see screenshot)](https://ibb.co/qW5TqLX). It breaks download process and you have to start again from zero bytes downloaded. 

However, `cached_download(..)` function in huggingface_hub has `resume_download` argument that can be used to restart download without loosing progress. See [this line](https://github.com/huggingface/huggingface_hub/blob/c16c3185e5d2e8d64f595e2cc1ea5bd7a96e4af5/src/huggingface_hub/file_download.py#L481). So i think it would be helpful to add it as optional argument(defaults to `False`) to the ` get_rudalle_model(..)` so users can turn it on if they have unstable internet.